### PR TITLE
rtk query code splitting using injectEndpoints, replaced legacy createWrapper to useWrappedStore

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,12 +2,16 @@ import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 import AppLayout from "@/layouts/AppLayout";
 import { wrapper } from "@/redux/store";
+import { Provider } from "react-redux";
 
-export function App({ Component, pageProps }: AppProps) {
+export function App({ Component, ...rest }: AppProps) {
+  const { store, props } = wrapper.useWrappedStore(rest);
   return (
-    <AppLayout>
-      <Component {...pageProps} />
-    </AppLayout>
+    <Provider store={store}>
+      <AppLayout>
+        <Component {...props.pageProps} />
+      </AppLayout>
+    </Provider>
   );
 }
 

--- a/src/redux/api/account/slice.tsx
+++ b/src/redux/api/account/slice.tsx
@@ -1,11 +1,10 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { AccountDetailsApiResponse } from "./types/AccountDetailsType";
 import { AccountListsApiResponse } from "./types/AcountListsType";
-import { apiSlice } from "../baseApi/slice";
+import { baseApi } from "../baseApi/slice";
 
 const tmdbApiKey = "api_key=684e3f73d1ca0e692a3016c028aabf72";
 
-export const accountApi = apiSlice.injectEndpoints({
+export const accountApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getAccountDetails: builder.query({
       query: ({ session_id, account_id }) =>

--- a/src/redux/api/authentication/slice.tsx
+++ b/src/redux/api/authentication/slice.tsx
@@ -1,14 +1,10 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { AuthTokenApiResponse } from "./types/AuthTokenType";
 import { AuthSessionApiResponse } from "./types/AuthSessionType";
+import { baseApi } from "../baseApi/slice";
 
 const tmdbApiKey = "api_key=684e3f73d1ca0e692a3016c028aabf72";
 
-export const authApi = createApi({
-  reducerPath: "authApi",
-  baseQuery: fetchBaseQuery({
-    baseUrl: "https://api.themoviedb.org/3",
-  }),
+export const authApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getAuthToken: builder.query({
       query: () => `/authentication/token/new?${tmdbApiKey}`,

--- a/src/redux/api/baseApi/slice.tsx
+++ b/src/redux/api/baseApi/slice.tsx
@@ -1,10 +1,16 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { HYDRATE } from "next-redux-wrapper";
 
-export const apiSlice = createApi({
-  reducerPath: "api",
+export const baseApi = createApi({
+  reducerPath: "baseApi",
   baseQuery: fetchBaseQuery({
     baseUrl: "https://api.themoviedb.org/3",
   }),
+  extractRehydrationInfo(action, { reducerPath }) {
+    if (action.type === HYDRATE) {
+      return action.payload[reducerPath];
+    }
+  },
   tagTypes: [],
   endpoints: (builder) => ({}),
 });

--- a/src/redux/api/configuration/slice.tsx
+++ b/src/redux/api/configuration/slice.tsx
@@ -1,14 +1,10 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { ConfigurationApiResponse } from "./types/ConfigurationType";
+import { baseApi } from "../baseApi/slice";
 
 
 const tmdbApiKey = "api_key=684e3f73d1ca0e692a3016c028aabf72";
 
-export const configurationApi = createApi({
-  reducerPath: "configurationApi",
-  baseQuery: fetchBaseQuery({
-    baseUrl: "https://api.themoviedb.org/3",
-  }),
+export const configurationApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getConfigurationLanguages: builder.query({
       query: () => `/configuration/languages?${tmdbApiKey}`,

--- a/src/redux/api/discover/slice.tsx
+++ b/src/redux/api/discover/slice.tsx
@@ -1,13 +1,9 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { MovieDiscoverApiResponse } from "./types/MovieDiscoverType";
+import { baseApi } from "../baseApi/slice";
 
 const tmdbApiKey = "api_key=684e3f73d1ca0e692a3016c028aabf72";
 
-export const discoverApi = createApi({
-  reducerPath: "discoverApi",
-  baseQuery: fetchBaseQuery({
-    baseUrl: "https://api.themoviedb.org/3",
-  }),
+export const discoverApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getMovieDiscover: builder.query({
       query: (params) => `/discover/movie?${tmdbApiKey}&${params}`,

--- a/src/redux/api/genres/slice.tsx
+++ b/src/redux/api/genres/slice.tsx
@@ -1,13 +1,9 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { MovieGenresResponseApi } from "./types/MovieListGenreType";
+import { baseApi } from "../baseApi/slice";
 
 const tmdbApiKey = "api_key=684e3f73d1ca0e692a3016c028aabf72";
 
-export const genresApi = createApi({
-  reducerPath: "genresApi",
-  baseQuery: fetchBaseQuery({
-    baseUrl: "https://api.themoviedb.org/3",
-  }),
+export const genresApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getMovieListGenre: builder.query({
       query: (params) => `/genre/movie/list?${tmdbApiKey}&${params ? params : ""}`,

--- a/src/redux/api/lists/slice.tsx
+++ b/src/redux/api/lists/slice.tsx
@@ -1,14 +1,10 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { ListDetailsApiResponse } from "./types/ListDetailsType";
 import { ListCreateApiResponse } from "./types/ListCreateType";
+import { baseApi } from "../baseApi/slice";
 
 const tmdbApiKey = "api_key=684e3f73d1ca0e692a3016c028aabf72";
 
-export const listsApi = createApi({
-  reducerPath: "listsApi",
-  baseQuery: fetchBaseQuery({
-    baseUrl: "https://api.themoviedb.org/3",
-  }),
+export const listsApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getListDetails: builder.query({
       query: ({ id, params }) =>

--- a/src/redux/api/movies/slice.tsx
+++ b/src/redux/api/movies/slice.tsx
@@ -1,6 +1,3 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { HYDRATE } from "next-redux-wrapper";
-
 import { ListMoviesApiResponse } from "./types/ListMovieType";
 import { MovieDetailsApiResponse } from "./types/MovieDetailsType";
 import { MovieReleaseDatesApiResponse } from "./types/MovieReleaseDates";
@@ -9,19 +6,12 @@ import { MovieImagesApiResponse } from "./types/MovieImagesType";
 import { MovieVideosApiResponse } from "./types/MovieVideosType";
 import { MovieRecsApiResponse } from "./types/MovieRecsType";
 import { MovieKeywordApiResponse } from "./types/MovieKeywordsType";
+import { baseApi } from "../baseApi/slice";
 
 const tmdbApiKey = "api_key=684e3f73d1ca0e692a3016c028aabf72";
 
-export const moviesApi = createApi({
-  reducerPath: "moviesApi",
-  baseQuery: fetchBaseQuery({
-    baseUrl: "https://api.themoviedb.org/3",
-  }),
-  extractRehydrationInfo(action, { reducerPath }) {
-    if (action.type === HYDRATE) {
-      return action.payload[reducerPath];
-    }
-  },
+export const moviesApi = baseApi.injectEndpoints({
+  
   endpoints: (builder) => ({
     getMovies: builder.query({
       query: ({ typeList, params }) =>

--- a/src/redux/api/search/slice.tsx
+++ b/src/redux/api/search/slice.tsx
@@ -1,13 +1,9 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { SearchKeywordApiResponse } from "./types/SearchKeywordType";
+import { baseApi } from "../baseApi/slice";
 
 const tmdbApiKey = "api_key=684e3f73d1ca0e692a3016c028aabf72";
 
-export const searchApi = createApi({
-  reducerPath: "searchApi",
-  baseQuery: fetchBaseQuery({
-    baseUrl: "https://api.themoviedb.org/3",
-  }),
+export const searchApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     getSearchKeywords: builder.query({
       query: (query) => `/search/keyword?${tmdbApiKey}&query=${query ? query : ""}`,

--- a/src/redux/store.tsx
+++ b/src/redux/store.tsx
@@ -1,14 +1,6 @@
-import { MiddlewareArray, configureStore } from "@reduxjs/toolkit";
+import { configureStore } from "@reduxjs/toolkit";
 
-import { authApi } from "./api/authentication/slice";
-import { accountApi } from "./api/account/slice";
-import { listsApi } from "./api/lists/slice";
-import { moviesApi } from "./api/movies/slice";
-import { discoverApi } from "./api/discover/slice";
-import { genresApi } from "./api/genres/slice";
-import { searchApi } from "./api/search/slice";
-import { configurationApi } from "./api/configuration/slice";
-import { apiSlice } from "./api/baseApi/slice";
+import { baseApi } from "./api/baseApi/slice";
 import paramsSlice from "./params/slice";
 
 import { createWrapper } from "next-redux-wrapper";
@@ -17,30 +9,12 @@ import { useDispatch } from "react-redux";
 const store = () =>
   configureStore({
     reducer: {
-      authApi: authApi.reducer,
-      [apiSlice.reducerPath]:apiSlice.reducer,
-      accountApi: accountApi.reducer,
-      listsApi: listsApi.reducer,
-      moviesApi: moviesApi.reducer,
-      genresApi: genresApi.reducer,
-      discoverApi: discoverApi.reducer,
-      searchApi: searchApi.reducer,
-      configurationApi: configurationApi.reducer,
+      baseApi: baseApi.reducer,
       paramsSlice: paramsSlice.reducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware() /* as MiddlewareArray<any> */
-        .concat([
-          apiSlice.middleware,
-          authApi.middleware,
-          accountApi.middleware,
-          listsApi.middleware,
-          moviesApi.middleware,
-          genresApi.middleware,
-          discoverApi.middleware,
-          searchApi.middleware,
-          configurationApi.middleware,
-        ]),
+        .concat(baseApi.middleware),
   });
 
 export default store;


### PR DESCRIPTION
Code splitting in the RTK Query structure has been implemented. According to the RTK Query documentation:

> "Typically, you should only have one API slice per base URL that your application needs to communicate with. For example, if your site fetches data from both /api/posts and /api/users, you would have a single API slice with /api/ as the base URL, and separate endpoint definitions for posts and users. This allows you to effectively take advantage of [automated re-fetching](https://redux-toolkit.js.org/rtk-query/usage/automated-refetching) by defining [tag](https://redux-toolkit.js.org/rtk-query/usage/automated-refetching#tags) relationships across endpoints.
> 
> For maintainability purposes, you may wish to split up endpoint definitions across multiple files, while still maintaining a single API slice which includes all of these endpoints. See [code splitting](https://redux-toolkit.js.org/rtk-query/usage/code-splitting) for how you can use the injectEndpoints property to inject API endpoints from other files into a single API slice definition."

Therefore, instead of having separate createApi instances for each API "section" all createApi instances have been combined into one baseApi and split using `injectEndpoints`. This will allow for more efficient data fetching and ensure proper handling of tags and data invalidation.

Additionally, according to the next-redux-wrapper documentation, `createWrapper `is a "legacy HOC that can work with class-based components." As a result, it has been replaced with `useWrapperStore`, which is used in _app.tsx.