### PR TITLE
try using runtime: experimental-edge in GSSP

### DIFF
--- a/src/pages/lists/[id].tsx
+++ b/src/pages/lists/[id].tsx
@@ -7,6 +7,19 @@ import DetailLayout from "@/layouts/DetailsLayout";
 import ListDetailsHead from "@/components/ListDetailsBlock/ListDetailsHead/ListDetailsHead";
 import ListDetailsBody from "@/components/ListDetailsBlock/ListDetailsBody/ListDetailsBody";
 
+/* 
+  The long cold start issue fix
+  Relative issues: 
+  #1 https://github.com/denvudd/react-dbmovies.github.io/issues/2
+  #2 https://github.com/vercel/next.js/discussions/50783#discussioncomment-6139352
+  #3 https://github.com/vercel/vercel/discussions/7961
+  Documentation links:
+  #1 https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props#getserversideprops-with-edge-api-routes
+*/
+export const config = {
+  runtime: 'experimental-edge', 
+}
+
 interface ListDetailsPageProps {
   id: number;
 }

--- a/src/pages/movies/[id].tsx
+++ b/src/pages/movies/[id].tsx
@@ -8,6 +8,19 @@ import DetailLayout from "@/layouts/DetailsLayout";
 import MovieDetailsBlock from "@/components/MovieDetailsBlock/MovieDetailsBlock";
 import { wrapper } from "@/redux/store";
 import { MovieDetails } from "@/redux/api/movies/types/MovieDetailsType";
+
+/* 
+  The long cold start issue fix
+  Relative issues: 
+  #1 https://github.com/denvudd/react-dbmovies.github.io/issues/2
+  #2 https://github.com/vercel/next.js/discussions/50783#discussioncomment-6139352
+  #3 https://github.com/vercel/vercel/discussions/7961
+  Documentation links:
+  #1 https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props#getserversideprops-with-edge-api-routes
+*/
+export const config = {
+  runtime: 'experimental-edge', 
+}
 interface MovieDetailsPageProps {
   id: number;
   data: MovieDetails;


### PR DESCRIPTION
The long cold start issue fix
  Relative issues: 
  #1 [Long initial page load with dynamic routing and getServerSideProps](https://github.com/denvudd/react-dbmovies.github.io/issues/2)
  #2 https://github.com/vercel/next.js/discussions/50783#discussioncomment-6139352
  #3 https://github.com/vercel/vercel/discussions/7961
  Documentation links:
  #1 https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props#getserversideprops-with-edge-api-routes