### PR TITLE
disable image optimization for vercel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const path = require("path");
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    unoptimized: true, // for development period
+    unoptimized: true, // for development period on Vercel (link: https://vercel.com/docs/concepts/image-optimization/managing-image-optimization-costs#how-to-minimize-image-optimization-costs)
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
Due to the account ban on Vercel, it has been decided to temporarily disable image optimization for the entire project as the limit has been exceeded. This recommendation comes from Vercel support.

https://vercel.com/docs/concepts/image-optimization/managing-image-optimization-costs#how-to-minimize-image-optimization-costs